### PR TITLE
Fixed unittest dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,4 +4,5 @@ version: 0.2.6-dev
 author: Dennis Kaselow <Dennis.Kaselow+dartemis@gmail.com>
 homepage: https://github.com/denniskaselow/dartemis
 dependencies:
-  unittest: any
+  unittest:
+    sdk: unittest


### PR DESCRIPTION
The unittest package is no longer hosted on pub.dartlang.org (http://pub.dartlang.org/packages/unittest shows 404) so "pub install" fails with the current pubspec.yaml

The package should be included from the sdk, as shown in the updated documentation:

http://api.dartlang.org/docs/bleeding_edge/unittest.html
