### PR TITLE
fixed system processing with more than 32 entities, fixes issue #55

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
-## 0.9.0
+## 0.9.2
+### Bugfix
+* handle more than 32 entities with the same components
+
+## 0.9.1
 ### Bugfix
 * handle more than 32 components when adding systems for components that haven't been used yet
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -30,6 +30,7 @@ linter:
     - avoid_js_rounded_ints
     - avoid_null_checks_in_equality_operators
     - avoid_positional_boolean_parameters
+    - avoid_print
     - avoid_private_typedef_functions
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters

--- a/example/darteroids/components.dart
+++ b/example/darteroids/components.dart
@@ -4,7 +4,7 @@ class CircularBody extends Component {
   num radius;
   String color;
 
-  CircularBody.down(this.radius, this.color);
+  CircularBody(this.radius, this.color);
 }
 
 class Position extends Component {

--- a/example/darteroids/gamelogic_systems.dart
+++ b/example/darteroids/gamelogic_systems.dart
@@ -63,7 +63,7 @@ class BulletSpawningSystem extends EntityProcessingSystem {
     world.createEntity([
       Position(shooterPos.x, shooterPos.y),
       Velocity(velX, velY),
-      CircularBody.down(2, 'red'),
+      CircularBody(2, 'red'),
       Decay(5000),
       AsteroidDestroyer(),
     ]);
@@ -136,7 +136,7 @@ class AsteroidDestructionSystem extends EntityProcessingSystem {
     final asteroid = world.createEntity([
       Position(asteroidPos.x, asteroidPos.y),
       Velocity(vx, vy),
-      CircularBody.down(radius, asteroidColor),
+      CircularBody(radius, asteroidColor),
       PlayerDestroyer(),
     ]);
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -45,7 +45,7 @@ class Darteroids {
     final player = world.createEntity([
       Position(maxWidth ~/ 2, maxHeight ~/ 2),
       Velocity(),
-      CircularBody.down(20, playerColor),
+      CircularBody(20, playerColor),
       Cannon(),
       Status(lifes: 3, invisiblityTimer: 5000),
     ]);
@@ -74,14 +74,14 @@ class Darteroids {
   }
 
   void addAsteroids(GroupManager groupManager) {
-    for (var i = 0; i < 10; i++) {
+    for (var i = 0; i < 33; i++) {
       final vx = generateRandomVelocity();
       final vy = generateRandomVelocity();
       final asteroid = world.createEntity([
         Position(
             maxWidth * random.nextDouble(), maxHeight * random.nextDouble()),
         Velocity(vx, vy),
-        CircularBody.down(10 + 20 * random.nextDouble(), asteroidColor),
+        CircularBody(5 + 10 * random.nextDouble(), asteroidColor),
         PlayerDestroyer(),
       ]);
       groupManager.add(asteroid, groupAsteroids);

--- a/lib/src/core/component_manager.dart
+++ b/lib/src/core/component_manager.dart
@@ -144,7 +144,7 @@ class ComponentManager extends Manager {
 
 class _ComponentInfo<T extends Component> {
   BitSet entities = BitSet(32);
-  List<T?> components = List.filled(32, null);
+  List<T?> components = List.filled(32, null, growable: true);
   BitSet interestedSystems = BitSet(32);
   BitSet requiresUpdate = BitSet(32);
   bool dirty = false;
@@ -155,8 +155,8 @@ class _ComponentInfo<T extends Component> {
     if (entity >= entities.length) {
       entities = BitSet.fromBitSet(entities, length: entity + 1);
       final newCapacity = (entities.length * 3) ~/ 2 + 1;
-      components = List<T?>.filled(newCapacity, null)
-        ..setRange(0, components.length, components);
+      final filler = List.filled(newCapacity - components.length, null);
+      components.addAll(filler);
     }
     entities[entity] = true;
     components[entity] = component;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dartemis
-version: 0.9.1
+version: 0.9.2
 description: An Entity System Framework for game development. Based on Artemis.
 homepage: https://github.com/denniskaselow/dartemis
 environment:

--- a/test/dartemis/core/world_test.dart
+++ b/test/dartemis/core/world_test.dart
@@ -260,6 +260,21 @@ Adding a component will get the entity processed''', () {
     test('world can handle more than 32 components referenced by systems', () {
       world.addSystem(TestEntitySystemWithMoreThan32Components());
     });
+    test(
+        'world can handle entites with an id higher than 32 when spawned later',
+        () {
+      final es = TestEntitySystemForComponent3();
+      world
+        ..addSystem(es)
+        ..initialize()
+        ..process();
+
+      for (var i = 0; i <= 32; i++) {
+        world.createEntity([Component3()]);
+      }
+
+      world.process();
+    });
   });
 }
 
@@ -333,4 +348,23 @@ class TestEntitySystemWithMoreThan32Components extends EntitySystem {
 
   @override
   bool checkProcessing() => true;
+}
+
+class TestEntitySystemForComponent3 extends EntityProcessingSystem {
+  late Mapper<Component3> mapper;
+
+  TestEntitySystemForComponent3() : super(Aspect.forAllOf([Component3]));
+
+  @override
+  void initialize() {
+    mapper = Mapper<Component3>(world);
+  }
+
+  @override
+  void processEntity(int entity) {
+    final component = mapper.getSafe(entity);
+
+    expect(component, isNotNull,
+        reason: 'component for entity $entity is null');
+  }
 }


### PR DESCRIPTION
fixed system processing with more than 32 entities, fixes issue #55

The update from 0.8.0 switched from `Bag` to `List` in the `ComponentMananger` for mapping the components. When the `Mapper` got created it referenced the `Bag`, and if new entities were added the `Bag` increased in size. After the change, the `List` didn't increase in size, instead a new instance was created, thus leaving the `Mapper` with an outdated `List`.