### PR TITLE
Added support to move a component between 2 entities

### DIFF
--- a/lib/src/core/component_manager.dart
+++ b/lib/src/core/component_manager.dart
@@ -58,6 +58,11 @@ class ComponentManager extends Manager {
     _componentInfoByType[typeId]!.remove(entity);
   }
 
+  void _moveComponent(int entitySrc, int entityDst, ComponentType type) {
+    final typeId = type._bitIndex;
+    _componentInfoByType[typeId]?.move(entitySrc, entityDst);
+  }
+
   /// Returns all components of [ComponentType type] accessible by their entity
   /// id.
   List<T?> _getComponentsByType<T extends Component>(ComponentType type) {
@@ -200,6 +205,17 @@ class _ComponentInfo<T extends Component> {
       entities[entity] = false;
       (components[entity])!._removed();
       components[entity] = null;
+      dirty = true;
+    }
+  }
+
+  void move(int srcEntity, int dstEntity) {
+    if (entities.length > srcEntity && entities[srcEntity]) {
+      remove(dstEntity);
+      entities[dstEntity] = true;
+      entities[srcEntity] = false;
+      components[dstEntity] = components[srcEntity];
+      components[srcEntity] = null;
       dirty = true;
     }
   }

--- a/lib/src/core/world.dart
+++ b/lib/src/core/world.dart
@@ -124,6 +124,13 @@ class World {
   void removeComponent<T extends Component>(int entity) =>
       componentManager._removeComponent(entity, ComponentType.getTypeFor(T));
 
+  /// moves a [Component] of type [T] from the [srcEntity] to the [dstEntity].
+  /// if the [srcEntity] does not have the [Component] of type [T] nothing will
+  /// happen.
+  void moveComponent<T extends Component>(int srcEntity, int dstEntity) =>
+      componentManager._moveComponent(
+          srcEntity, dstEntity, ComponentType.getTypeFor(T));
+
   /// Gives you all the systems in this world for possible iteration.
   Iterable<EntitySystem> get systems => _systemsList;
 

--- a/test/dartemis/core/world_test.dart
+++ b/test/dartemis/core/world_test.dart
@@ -334,11 +334,13 @@ Adding a component will get the entity processed''', () {
     late World world;
     late int entityA;
     late int entityB;
+    late int entityC;
     late TestEntitySystem es;
     setUp(() {
       world = World();
       entityA = world.createEntity([Component0(), Component32()]);
       entityB = world.createEntity([Component32()]);
+      entityC = world.createEntity([Component0()]);
       final expectedEntities = [entityA];
       es = TestEntitySystem(Aspect.forAllOf([Component0]), expectedEntities);
 
@@ -370,6 +372,27 @@ Adding a component will get the entity processed''', () {
       world.removeComponent<Component0>(entityA);
 
       expect(world.componentManager.isUpdateNeededForSystem(es), isTrue);
+    });
+    test(
+        'systems should require update when component required by system is '
+        'moved', () {
+      world.moveComponent<Component0>(entityA, entityC);
+
+      expect(world.componentManager.isUpdateNeededForSystem(es), isTrue);
+    });
+    test(
+        'systems should require update when component required by system is '
+        'moved to a entity  that did not have the component before', () {
+      world.moveComponent<Component0>(entityA, entityB);
+
+      expect(world.componentManager.isUpdateNeededForSystem(es), isTrue);
+    });
+    test(
+        'systems should not require update when component required by system is '
+        'moved', () {
+      world.moveComponent<Component32>(entityA, entityB);
+
+      expect(world.componentManager.isUpdateNeededForSystem(es), isFalse);
     });
     test(
         'systems should require update when component required by system is '

--- a/test/dartemis/core/world_test.mocks.dart
+++ b/test/dartemis/core/world_test.mocks.dart
@@ -157,6 +157,15 @@ class MockEntitySystem2 extends _i1.Mock
         returnValueForMissingStub: null,
       );
   @override
+  void moveComponent<T extends _i2.Component>(int? srcEntity, int? dstEntity) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #removeComponent,
+          [srcEntity, dstEntity],
+        ),
+        returnValueForMissingStub: null,
+      );
+  @override
   void deleteFromWorld(int? entity) => super.noSuchMethod(
         Invocation.method(
           #deleteFromWorld,


### PR DESCRIPTION
These changes allow moving a component between entities without having to copy the component. It is safe with pooled components and regular components.
the move is skipped if the source entity does not have the component. If the destination entity has a similar component it'll be cleaned up properly before being replaced.
The source entity will lose the moved component without being cleaned up.