### PR TITLE
Fix crash when moving components

### DIFF
--- a/lib/src/core/component_manager.dart
+++ b/lib/src/core/component_manager.dart
@@ -212,9 +212,8 @@ class _ComponentInfo<T extends Component> {
   void move(int srcEntity, int dstEntity) {
     if (entities.length > srcEntity && entities[srcEntity]) {
       remove(dstEntity);
-      entities[dstEntity] = true;
+      this[dstEntity] = components[srcEntity]!;
       entities[srcEntity] = false;
-      components[dstEntity] = components[srcEntity];
       components[srcEntity] = null;
       dirty = true;
     }

--- a/test/dartemis/core/component_test.dart
+++ b/test/dartemis/core/component_test.dart
@@ -29,5 +29,19 @@ void main() {
       world.removeComponent<PooledComponent2>(entity);
       expect(PooledComponent2(), same(c));
     });
+
+    test('moving components should not crash', () {
+      final entity0 = world.createEntity();
+      world.addComponent(entity0, PooledComponent2());
+
+      var previousEntity = entity0;
+      for (var i = 0; i < 128; i++) {
+        final entity = world.createEntity();
+        world.moveComponent<PooledComponent2>(previousEntity, entity);
+        previousEntity = entity;
+      }
+
+      expect(world.getComponents(previousEntity), isNotEmpty);
+    });
   });
 }


### PR DESCRIPTION
There is a crash in the `moveComponent` feature when the destination entity is out of bounds of the bitset for the given component.
I've fixed the crash and added a unit test that moves the component around a large number of entities.