### PR TITLE
Use extension types to use Entity instead of int for entities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# Dependabot configuration file.
+# See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
+
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    labels:
+      - autosubmit
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 * Entities are no longer simple `int`s and have been turned into an `extension type Entity(int)`. 
   Methods that previously expected `int entity` or `Iterable<int> entities>` 
   now expect `Entity entity` or `Iterable<Entity> entities`.
+* Removed named parameters `group` and `passive` from `World.addSystem`,
+  they are now named parameters of the constructor of `EntitySystem`.
+* The `initialize`-method of `Manager`s and `EntitySystem`s now has a
+  parameter for the `World`.
 
 ## 0.9.9
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## 0.10.0
+### Breaking API Changes
+* Entities are no longer simple `int`s and have been turned into an `extension type Entity(int)`. 
+  Methods that previously expected `int entity` or `Iterable<int> entities>` 
+  now expect `Entity entity` or `Iterable<Entity> entities`.
+
 ## 0.9.9
 ### Enhancements
 * new method `getTag` in `TagManager` to get the tag of an entity

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Getting started
        velocityMapper = Mapper<Velocity>(world);
      }
 
-     void processEntity(int entity) {
+     void processEntity(Entity entity) {
        Position position = positionMapper[entity];
        Velocity vel = velocityMapper[entity];
        position
@@ -122,7 +122,7 @@ Getting started
    )
    class SimpleMovementSystem extends _$SimpleMovementSystem {
      @override
-     void processEntity(int entity, Position position, Velocity velocity) {    
+     void processEntity(Entity entity, Position position, Velocity velocity) {    
        position
          ..x += velocity.x * world.delta
          ..y += velocity.y * world.delta;

--- a/example/darteroids/gamelogic_systems.dart
+++ b/example/darteroids/gamelogic_systems.dart
@@ -13,7 +13,7 @@ class MovementSystem extends EntityProcessingSystem {
   }
 
   @override
-  void processEntity(int entity) {
+  void processEntity(Entity entity) {
     final pos = positionMapper[entity];
     final vel = velocityMapper[entity];
 
@@ -40,7 +40,7 @@ class BulletSpawningSystem extends EntityProcessingSystem {
   }
 
   @override
-  void processEntity(int entity) {
+  void processEntity(Entity entity) {
     final cannon = cannonMapper[entity];
 
     if (cannon.canShoot) {
@@ -81,7 +81,7 @@ class DecaySystem extends EntityProcessingSystem {
   }
 
   @override
-  void processEntity(int entity) {
+  void processEntity(Entity entity) {
     final decay = decayMapper[entity];
 
     if (decay.timer < 0) {
@@ -109,7 +109,7 @@ class AsteroidDestructionSystem extends EntityProcessingSystem {
   }
 
   @override
-  void processEntity(int entity) {
+  void processEntity(Entity entity) {
     final destroyerPos = positionMapper[entity];
 
     for (final asteroid in groupManager.getEntities(groupAsteroids)) {
@@ -168,7 +168,7 @@ class PlayerCollisionDetectionSystem extends EntitySystem {
   }
 
   @override
-  void processEntities(Iterable<int> entities) {
+  void processEntities(Iterable<Entity> entities) {
     final player = tagManager.getEntity(tagPlayer)!;
     final playerPos = positionMapper[player];
     final playerStatus = statusMapper[player];

--- a/example/darteroids/gamelogic_systems.dart
+++ b/example/darteroids/gamelogic_systems.dart
@@ -7,7 +7,8 @@ class MovementSystem extends EntityProcessingSystem {
   MovementSystem() : super(Aspect.forAllOf([Position, Velocity]));
 
   @override
-  void initialize() {
+  void initialize(World world) {
+    super.initialize(world);
     positionMapper = Mapper<Position>(world);
     velocityMapper = Mapper<Velocity>(world);
   }
@@ -33,7 +34,8 @@ class BulletSpawningSystem extends EntityProcessingSystem {
   BulletSpawningSystem() : super(Aspect.forAllOf([Cannon, Position, Velocity]));
 
   @override
-  void initialize() {
+  void initialize(World world) {
+    super.initialize(world);
     positionMapper = Mapper<Position>(world);
     cannonMapper = Mapper<Cannon>(world);
     velocityMapper = Mapper<Velocity>(world);
@@ -76,7 +78,8 @@ class DecaySystem extends EntityProcessingSystem {
   DecaySystem() : super(Aspect.forAllOf([Decay]));
 
   @override
-  void initialize() {
+  void initialize(World world) {
+    super.initialize(world);
     decayMapper = Mapper<Decay>(world);
   }
 
@@ -102,7 +105,8 @@ class AsteroidDestructionSystem extends EntityProcessingSystem {
       : super(Aspect.forAllOf([AsteroidDestroyer, Position]));
 
   @override
-  void initialize() {
+  void initialize(World world) {
+    super.initialize(world);
     positionMapper = Mapper<Position>(world);
     bodyMapper = Mapper<CircularBody>(world);
     groupManager = world.getManager<GroupManager>();
@@ -160,7 +164,8 @@ class PlayerCollisionDetectionSystem extends EntitySystem {
       : super(Aspect.forAllOf([PlayerDestroyer, Position, CircularBody]));
 
   @override
-  void initialize() {
+  void initialize(World world) {
+    super.initialize(world);
     positionMapper = Mapper<Position>(world);
     statusMapper = Mapper<Status>(world);
     bodyMapper = Mapper<CircularBody>(world);

--- a/example/darteroids/input_systems.dart
+++ b/example/darteroids/input_systems.dart
@@ -37,7 +37,7 @@ class PlayerControlSystem extends IntervalEntitySystem {
   }
 
   @override
-  void processEntities(Iterable<int> entities) {
+  void processEntities(Iterable<Entity> entities) {
     final player = tagManager.getEntity(tagPlayer)!;
     final velocity = velocityMapper[player];
     final cannon = cannonMapper[player];

--- a/example/darteroids/input_systems.dart
+++ b/example/darteroids/input_systems.dart
@@ -25,7 +25,8 @@ class PlayerControlSystem extends IntervalEntitySystem {
       : super(20, Aspect.forAllOf([Velocity, Cannon]));
 
   @override
-  void initialize() {
+  void initialize(World world) {
+    super.initialize(world);
     tagManager = world.getManager<TagManager>();
     velocityMapper = Mapper<Velocity>(world);
     cannonMapper = Mapper<Cannon>(world);

--- a/example/darteroids/render_systems.dart
+++ b/example/darteroids/render_systems.dart
@@ -18,7 +18,7 @@ class CircleRenderingSystem extends EntityProcessingSystem {
   }
 
   @override
-  void processEntity(int entity) {
+  void processEntity(Entity entity) {
     final pos = positionMapper[entity];
     final body = bodyMapper[entity];
     final status = statusMapper.getSafe(entity);

--- a/example/darteroids/render_systems.dart
+++ b/example/darteroids/render_systems.dart
@@ -7,11 +7,12 @@ class CircleRenderingSystem extends EntityProcessingSystem {
   late final Mapper<CircularBody> bodyMapper;
   late final Mapper<Status> statusMapper;
 
-  CircleRenderingSystem(this.context)
+  CircleRenderingSystem(this.context, {super.group})
       : super(Aspect.forAllOf([Position, CircularBody]));
 
   @override
-  void initialize() {
+  void initialize(World world) {
+    super.initialize(world);
     positionMapper = Mapper<Position>(world);
     statusMapper = Mapper<Status>(world);
     bodyMapper = Mapper<CircularBody>(world);
@@ -72,7 +73,7 @@ class CircleRenderingSystem extends EntityProcessingSystem {
 class BackgroundRenderSystem extends VoidEntitySystem {
   final CanvasRenderingContext2D context;
 
-  BackgroundRenderSystem(this.context);
+  BackgroundRenderSystem(this.context, {super.group});
 
   @override
   void processSystem() {
@@ -95,10 +96,11 @@ class HudRenderSystem extends VoidEntitySystem {
   late final TagManager tagManager;
   late final Mapper<Status> statusMapper;
 
-  HudRenderSystem(this.context);
+  HudRenderSystem(this.context, {super.group});
 
   @override
-  void initialize() {
+  void initialize(World world) {
+    super.initialize(world);
     tagManager = world.getManager<TagManager>();
     statusMapper = Mapper<Status>(world);
   }

--- a/example/main.dart
+++ b/example/main.dart
@@ -3,14 +3,12 @@ library darteroids;
 import 'dart:async';
 import 'dart:html';
 import 'dart:math';
+
 import 'package:dartemis/dartemis.dart';
 
 part 'darteroids/components.dart';
-
 part 'darteroids/gamelogic_systems.dart';
-
 part 'darteroids/input_systems.dart';
-
 part 'darteroids/render_systems.dart';
 
 const String tagPlayer = 'player';
@@ -65,9 +63,9 @@ class Darteroids {
       ..addSystem(MovementSystem())
       ..addSystem(AsteroidDestructionSystem())
       ..addSystem(PlayerCollisionDetectionSystem())
-      ..addSystem(BackgroundRenderSystem(context2d), group: 1)
-      ..addSystem(CircleRenderingSystem(context2d), group: 1)
-      ..addSystem(HudRenderSystem(context2d), group: 1)
+      ..addSystem(BackgroundRenderSystem(context2d, group: 1))
+      ..addSystem(CircleRenderingSystem(context2d, group: 1))
+      ..addSystem(HudRenderSystem(context2d, group: 1))
       ..initialize();
 
     physicsLoop();

--- a/lib/dartemis.dart
+++ b/lib/dartemis.dart
@@ -11,6 +11,7 @@ part 'src/core/aspect.dart';
 part 'src/core/component.dart';
 part 'src/core/component_manager.dart';
 part 'src/core/component_type.dart';
+part 'src/core/entity.dart';
 part 'src/core/entity_manager.dart';
 part 'src/core/entity_observer.dart';
 part 'src/core/entity_system.dart';

--- a/lib/src/core/component_manager.dart
+++ b/lib/src/core/component_manager.dart
@@ -7,11 +7,14 @@ class ComponentManager extends Manager {
   ComponentManager._internal() : _componentInfoByType = Bag<_ComponentInfo>();
 
   @override
-  void initialize() {}
+  void initialize(World world) {
+    super.initialize(world);
+  }
 
   /// Register a system to know if it needs to be updated when an entity
   /// changed.
-  void _registerSystem(EntitySystem system) {
+  @visibleForTesting
+  void registerSystem(EntitySystem system) {
     final systemBitIndex = system._systemBitIndex;
     for (final index in system._interestingComponentsIndices) {
       _componentInfoByType._ensureCapacity(index);
@@ -32,7 +35,9 @@ class ComponentManager extends Manager {
     }
   }
 
-  void _removeComponentsOfEntity(Entity entity) {
+  /// Removes all components from the [entity].
+  @visibleForTesting
+  void removeComponentsOfEntity(Entity entity) {
     _forComponentsOfEntity(entity, (components) {
       components.remove(entity);
     });
@@ -247,15 +252,4 @@ class _ComponentInfo<T extends Component> {
       requiresUpdate[systemBitIndex] = false;
 
   _ComponentInfo<S> cast<S extends Component>() => this as _ComponentInfo<S>;
-}
-
-/// For Testing.
-@visibleForTesting
-mixin MockComponentManagerMixin implements ComponentManager {
-  @override
-  late World _world;
-  @override
-  void _registerSystem(EntitySystem system) {}
-  @override
-  void _removeComponentsOfEntity(Entity entity) {}
 }

--- a/lib/src/core/entity.dart
+++ b/lib/src/core/entity.dart
@@ -1,0 +1,7 @@
+part of '../../dartemis.dart';
+
+/// The Entity type. Cannot be instantiated outside of dartemis. You must
+/// create new entities using [World.createEntity].
+extension type Entity(int _id) {
+  Entity._(this._id);
+}

--- a/lib/src/core/entity_manager.dart
+++ b/lib/src/core/entity_manager.dart
@@ -4,41 +4,41 @@ part of '../../dartemis.dart';
 /// basic statistcs.
 class EntityManager extends Manager {
   BitSet _entities;
-  final Bag<int> _deletedEntities;
+  final Bag<Entity> _deletedEntities;
 
   int _active = 0;
   int _added = 0;
   int _created = 0;
   int _deleted = 0;
 
-  final _IdentifierPool _identifierPool;
+  final _EntityPool _identifierPool;
 
   EntityManager._internal()
       : _entities = BitSet(32),
-        _deletedEntities = Bag<int>(),
-        _identifierPool = _IdentifierPool();
+        _deletedEntities = Bag<Entity>(),
+        _identifierPool = _EntityPool();
 
   @override
   void initialize() {}
 
-  int _createEntityInstance() {
+  Entity _createEntityInstance() {
     final entity = _deletedEntities.removeLast() ?? _identifierPool.checkOut();
     _created++;
     return entity;
   }
 
-  void _add(int entity) {
+  void _add(Entity entity) {
     _active++;
     _added++;
-    if (entity >= _entities.length) {
-      _entities = BitSet.fromBitSet(_entities, length: entity + 1);
+    if (entity._id >= _entities.length) {
+      _entities = BitSet.fromBitSet(_entities, length: entity._id + 1);
     }
-    _entities[entity] = true;
+    _entities[entity._id] = true;
   }
 
-  void _delete(int entity) {
-    if (_entities[entity]) {
-      _entities[entity] = false;
+  void _delete(Entity entity) {
+    if (_entities[entity._id]) {
+      _entities[entity._id] = false;
 
       _deletedEntities.add(entity);
 
@@ -49,7 +49,7 @@ class EntityManager extends Manager {
 
   /// Check if this entity is active.
   /// Active means the entity is being actively processed.
-  bool isActive(int entityId) => _entities[entityId];
+  bool isActive(Entity entity) => _entities[entity._id];
 
   /// Get how many entities are active in this world.
   int get activeEntityCount => _active;
@@ -67,18 +67,18 @@ class EntityManager extends Manager {
 }
 
 /// Used only internally to generate distinct ids for entities and reuse them.
-class _IdentifierPool {
-  final List<int> _ids = [];
+class _EntityPool {
+  final List<Entity> _entities = [];
   int _nextAvailableId = 0;
 
-  _IdentifierPool();
+  _EntityPool();
 
-  int checkOut() {
-    if (_ids.isNotEmpty) {
-      return _ids.removeLast();
+  Entity checkOut() {
+    if (_entities.isNotEmpty) {
+      return _entities.removeLast();
     }
-    return _nextAvailableId++;
+    return Entity._(_nextAvailableId++);
   }
 
-  void checkIn(int id) => _ids.add(id);
+  void checkIn(Entity entity) => _entities.add(entity);
 }

--- a/lib/src/core/entity_manager.dart
+++ b/lib/src/core/entity_manager.dart
@@ -19,7 +19,9 @@ class EntityManager extends Manager {
         _identifierPool = _EntityPool();
 
   @override
-  void initialize() {}
+  void initialize(World world) {
+    super.initialize(world);
+  }
 
   Entity _createEntityInstance() {
     final entity = _deletedEntities.removeLast() ?? _identifierPool.checkOut();

--- a/lib/src/core/entity_observer.dart
+++ b/lib/src/core/entity_observer.dart
@@ -4,8 +4,8 @@ part of '../../dartemis.dart';
 /// to the state of an [int].
 abstract class EntityObserver {
   /// Called when an [entity] is added to the world.
-  void added(int entity);
+  void added(Entity entity);
 
   /// Called when an [entity] is being deleted from the world.
-  void deleted(int entity);
+  void deleted(Entity entity);
 }

--- a/lib/src/core/entity_system.dart
+++ b/lib/src/core/entity_system.dart
@@ -10,10 +10,7 @@ abstract class EntitySystem {
   late final int _systemBitIndex;
   late final World _world;
 
-  // false positive: https://github.com/dart-lang/sdk/issues/39935
-  // ignore: prefer_final_fields
-  List<int> _actives = [];
-  // ignore: prefer_final_fields
+  List<Entity> _actives = [];
   bool _passive = true;
   late final List<int> _interestingComponentsIndices;
   late final List<int> _componentIndicesAll;
@@ -85,7 +82,7 @@ abstract class EntitySystem {
 
   /// Any implementing entity system must implement this method and the logic
   /// to process the given [entities] of the system.
-  void processEntities(Iterable<int> entities);
+  void processEntities(Iterable<Entity> entities);
 
   /// Returns true if the system should be processed, false if not.
   bool checkProcessing() => true;
@@ -99,15 +96,15 @@ abstract class EntitySystem {
   void destroy() {}
 
   /// Add a [component] to an [entity].
-  void addComponent<T extends Component>(int entity, T component) =>
+  void addComponent<T extends Component>(Entity entity, T component) =>
       world.addComponent(entity, component);
 
   /// Remove the component with type [T] from an [entity].
-  void removeComponent<T extends Component>(int entity) =>
+  void removeComponent<T extends Component>(Entity entity) =>
       world.removeComponent<T>(entity);
 
   /// Delete [entity] from the world.
-  void deleteFromWorld(int entity) => world.deleteEntity(entity);
+  void deleteFromWorld(Entity entity) => world.deleteEntity(entity);
 }
 
 /// For Testing.

--- a/lib/src/core/manager.dart
+++ b/lib/src/core/manager.dart
@@ -2,7 +2,7 @@ part of '../../dartemis.dart';
 
 /// Manager.
 abstract class Manager implements EntityObserver {
-  late World _world;
+  late final World _world;
 
   /// The [World] where this manager resides.
   World get world => _world;
@@ -12,10 +12,10 @@ abstract class Manager implements EntityObserver {
   void initialize() {}
 
   @override
-  void added(int entity) {}
+  void added(Entity entity) {}
 
   @override
-  void deleted(int entity) {}
+  void deleted(Entity entity) {}
 
   /// Called when the world gets destroyed. Override if you need to clean up
   /// your manager.

--- a/lib/src/core/manager.dart
+++ b/lib/src/core/manager.dart
@@ -9,7 +9,12 @@ abstract class Manager implements EntityObserver {
 
   /// Override to implement code that gets executed when managers are
   /// initialized.
-  void initialize() {}
+  @mustCallSuper
+  @protected
+  // ignore: use_setters_to_change_properties
+  void initialize(World world) {
+    _world = world;
+  }
 
   @override
   void added(Entity entity) {}
@@ -20,11 +25,4 @@ abstract class Manager implements EntityObserver {
   /// Called when the world gets destroyed. Override if you need to clean up
   /// your manager.
   void destroy() {}
-}
-
-/// For Testing.
-@visibleForTesting
-mixin MockManagerMixin implements Manager {
-  @override
-  late World _world;
 }

--- a/lib/src/core/managers/group_manager.dart
+++ b/lib/src/core/managers/group_manager.dart
@@ -6,28 +6,28 @@ part of '../../../dartemis.dart';
 ///
 /// An [int] can only belong to several groups (0,n) at a time.
 class GroupManager extends Manager {
-  final Map<String, Bag<int>> _entitiesByGroup;
-  final Map<int, Bag<String>> _groupsByEntity;
+  final Map<String, EntityBag> _entitiesByGroup;
+  final Map<Entity, Bag<String>> _groupsByEntity;
 
   /// Creates the [GroupManager].
   GroupManager()
-      : _entitiesByGroup = <String, Bag<int>>{},
-        _groupsByEntity = <int, Bag<String>>{};
+      : _entitiesByGroup = <String, EntityBag>{},
+        _groupsByEntity = <Entity, Bag<String>>{};
 
   /// Set the group of the entity.
-  void add(int entity, String group) {
-    _entitiesByGroup.putIfAbsent(group, Bag<int>.new).add(entity);
+  void add(Entity entity, String group) {
+    _entitiesByGroup.putIfAbsent(group, EntityBag.new).add(entity);
     _groupsByEntity.putIfAbsent(entity, Bag<String>.new).add(group);
   }
 
   /// Remove the entity from the specified group.
-  void remove(int entity, String group) {
+  void remove(Entity entity, String group) {
     _entitiesByGroup[group]?.remove(entity);
     _groupsByEntity[entity]?.remove(group);
   }
 
   /// Remove [entity] from all existing groups.
-  void removeFromAllGroups(int entity) {
+  void removeFromAllGroups(Entity entity) {
     final groups = _groupsByEntity[entity];
     if (groups != null) {
       groups
@@ -39,21 +39,21 @@ class GroupManager extends Manager {
   }
 
   /// Get all entities that belong to the provided group.
-  Iterable<int> getEntities(String group) =>
-      _entitiesByGroup.putIfAbsent(group, Bag<int>.new);
+  Iterable<Entity> getEntities(String group) =>
+      _entitiesByGroup.putIfAbsent(group, EntityBag.new);
 
   /// Returns the groups the entity belongs to, null if none.
-  Iterable<String>? getGroups(int entity) => _groupsByEntity[entity];
+  Iterable<String>? getGroups(Entity entity) => _groupsByEntity[entity];
 
   /// Checks if the entity belongs to any group.
-  bool isInAnyGroup(int entity) => getGroups(entity) != null;
+  bool isInAnyGroup(Entity entity) => getGroups(entity) != null;
 
   /// Check if the entity is in the supplied group.
-  bool isInGroup(int entity, String group) {
+  bool isInGroup(Entity entity, String group) {
     final groups = _groupsByEntity[entity];
     return (groups != null) && groups.contains(group);
   }
 
   @override
-  void deleted(int entity) => removeFromAllGroups(entity);
+  void deleted(Entity entity) => removeFromAllGroups(entity);
 }

--- a/lib/src/core/managers/player_manager.dart
+++ b/lib/src/core/managers/player_manager.dart
@@ -4,26 +4,26 @@ part of '../../../dartemis.dart';
 ///
 /// An entity can only belong to a single player at a time.
 class PlayerManager extends Manager {
-  final Map<int, String?> _playerByEntity;
-  final Map<String, Bag<int>> _entitiesByPlayer;
+  final Map<Entity, String?> _playerByEntity;
+  final Map<String, EntityBag> _entitiesByPlayer;
 
   /// Creates the [PlayerManager].
   PlayerManager()
-      : _playerByEntity = <int, String>{},
-        _entitiesByPlayer = <String, Bag<int>>{};
+      : _playerByEntity = <Entity, String>{},
+        _entitiesByPlayer = <String, EntityBag>{};
 
   /// Make [entity] belong to [player].
-  void setPlayer(int entity, String player) {
+  void setPlayer(Entity entity, String player) {
     _playerByEntity[entity] = player;
-    _entitiesByPlayer.putIfAbsent(player, Bag<int>.new).add(entity);
+    _entitiesByPlayer.putIfAbsent(player, EntityBag.new).add(entity);
   }
 
   /// Returns all entities that belong to [player].
-  Iterable<int> getEntitiesOfPlayer(String player) =>
-      _entitiesByPlayer[player] ??= Bag<int>();
+  Iterable<Entity> getEntitiesOfPlayer(String player) =>
+      _entitiesByPlayer[player] ??= EntityBag();
 
   /// Removes [entity] from the player it is associated with.
-  void removeFromPlayer(int entity) {
+  void removeFromPlayer(Entity entity) {
     final player = _playerByEntity[entity];
     if (player != null) {
       _entitiesByPlayer[player]?.remove(entity);
@@ -31,8 +31,8 @@ class PlayerManager extends Manager {
   }
 
   /// Returns the player associated with [entity].
-  String? getPlayer(int entity) => _playerByEntity[entity];
+  String? getPlayer(Entity entity) => _playerByEntity[entity];
 
   @override
-  void deleted(int entity) => removeFromPlayer(entity);
+  void deleted(Entity entity) => removeFromPlayer(entity);
 }

--- a/lib/src/core/managers/tag_manager.dart
+++ b/lib/src/core/managers/tag_manager.dart
@@ -4,16 +4,16 @@ part of '../../../dartemis.dart';
 /// entities such as "PLAYER", "BOSS" or something that is very unique.
 /// An entity can only belong to one tag (0,1) at a time.
 class TagManager extends Manager {
-  final Map<String, int?> _entitiesByTag;
-  final Map<int, String?> _tagsByEntity;
+  final Map<String, Entity?> _entitiesByTag;
+  final Map<Entity, String?> _tagsByEntity;
 
   /// Create the [TagManager].
   TagManager()
-      : _entitiesByTag = <String, int>{},
-        _tagsByEntity = <int, String>{};
+      : _entitiesByTag = <String, Entity>{},
+        _tagsByEntity = <Entity, String>{};
 
   /// Register a [tag] to an [entity].
-  void register(int entity, String tag) {
+  void register(Entity entity, String tag) {
     unregister(tag);
     _entitiesByTag[tag] = entity;
     _tagsByEntity[entity] = tag;
@@ -28,17 +28,17 @@ class TagManager extends Manager {
   bool isRegistered(String tag) => _entitiesByTag.containsKey(tag);
 
   /// Returns the entity with [tag].
-  int? getEntity(String tag) => _entitiesByTag[tag];
+  Entity? getEntity(String tag) => _entitiesByTag[tag];
 
   /// Returns the tag of the [entity].
-  String? getTag(int entity) => _tagsByEntity[entity];
+  String? getTag(Entity entity) => _tagsByEntity[entity];
 
   /// Returns all known tags.
   Iterable<String> getRegisteredTags() =>
       _tagsByEntity.values as Iterable<String>;
 
   @override
-  void deleted(int entity) {
+  void deleted(Entity entity) {
     final removedTag = _tagsByEntity.remove(entity);
     if (removedTag != null) {
       _entitiesByTag.remove(removedTag);

--- a/lib/src/core/mapper.dart
+++ b/lib/src/core/mapper.dart
@@ -14,19 +14,19 @@ class Mapper<T extends Component> {
   /// No bounding checks, so this could throw a [RangeError],
   /// however in most scenarios you already know the entity possesses this
   /// component.
-  T operator [](int entity) => _components[entity]!;
+  T operator [](Entity entity) => _components[entity._id]!;
 
   /// Fast and safe retrieval of a component for this entity.
   /// If the entity does not have this component then null is returned.
-  T? getSafe(int entity) {
-    if (_components.length > entity) {
-      return _components[entity];
+  T? getSafe(Entity entity) {
+    if (_components.length > entity._id) {
+      return _components[entity._id];
     }
     return null;
   }
 
   /// Checks if the entity has this type of component.
-  bool has(int entity) => getSafe(entity) != null;
+  bool has(Entity entity) => getSafe(entity) != null;
 }
 
 /// Same as [Mapper], except the [[]] operator returns [T?] instead of [T] and
@@ -42,13 +42,13 @@ class OptionalMapper<T extends Component> {
 
   /// Fast and safe retrieval of a component for this entity.
   /// If the entity does not have this component then null is returned.
-  T? operator [](int entity) {
-    if (_components.length > entity) {
-      return _components[entity];
+  T? operator [](Entity entity) {
+    if (_components.length > entity._id) {
+      return _components[entity._id];
     }
     return null;
   }
 
   /// Checks if the entity has this type of component.
-  bool has(int entity) => this[entity] != null;
+  bool has(Entity entity) => this[entity] != null;
 }

--- a/lib/src/core/systems/entity_processing_system.dart
+++ b/lib/src/core/systems/entity_processing_system.dart
@@ -4,7 +4,7 @@ part of '../../../dartemis.dart';
 /// possessing the provided component types.
 abstract class EntityProcessingSystem extends EntitySystem {
   /// Create a new [EntityProcessingSystem]. It requires at least one component.
-  EntityProcessingSystem(super.aspect);
+  EntityProcessingSystem(super.aspect, {super.group, super.passive});
 
   /// Process an [entity] this system is interested in.
   void processEntity(Entity entity);

--- a/lib/src/core/systems/entity_processing_system.dart
+++ b/lib/src/core/systems/entity_processing_system.dart
@@ -6,10 +6,10 @@ abstract class EntityProcessingSystem extends EntitySystem {
   /// Create a new [EntityProcessingSystem]. It requires at least one component.
   EntityProcessingSystem(super.aspect);
 
-  /// Process a [entity] this system is interested in.
-  void processEntity(int entity);
+  /// Process an [entity] this system is interested in.
+  void processEntity(Entity entity);
 
   @override
-  void processEntities(Iterable<int> entities) =>
+  void processEntities(Iterable<Entity> entities) =>
       entities.forEach(processEntity);
 }

--- a/lib/src/core/systems/interval_entity_processing_system.dart
+++ b/lib/src/core/systems/interval_entity_processing_system.dart
@@ -7,7 +7,12 @@ part of '../../../dartemis.dart';
 abstract class IntervalEntityProcessingSystem extends IntervalEntitySystem {
   /// Create a new [IntervalEntityProcessingSystem]. It requires at least one
   /// component.
-  IntervalEntityProcessingSystem(super.interval, super.aspect);
+  IntervalEntityProcessingSystem(
+    super.interval,
+    super.aspect, {
+    super.group,
+    super.passive,
+  });
 
   /// Process an [entity] this system is interested in.
   void processEntity(Entity entity);

--- a/lib/src/core/systems/interval_entity_processing_system.dart
+++ b/lib/src/core/systems/interval_entity_processing_system.dart
@@ -10,9 +10,9 @@ abstract class IntervalEntityProcessingSystem extends IntervalEntitySystem {
   IntervalEntityProcessingSystem(super.interval, super.aspect);
 
   /// Process an [entity] this system is interested in.
-  void processEntity(int entity);
+  void processEntity(Entity entity);
 
   @override
-  void processEntities(Iterable<int> entities) =>
+  void processEntities(Iterable<Entity> entities) =>
       entities.forEach(processEntity);
 }

--- a/lib/src/core/systems/interval_entity_system.dart
+++ b/lib/src/core/systems/interval_entity_system.dart
@@ -11,7 +11,12 @@ abstract class IntervalEntitySystem extends EntitySystem {
 
   /// Create an [IntervalEntitySystem] with the specified [interval] and
   /// [aspect].
-  IntervalEntitySystem(this.interval, Aspect aspect) : super(aspect);
+  IntervalEntitySystem(
+    this.interval,
+    super.aspect, {
+    super.group,
+    super.passive,
+  });
 
   /// Returns the accumulated delta since the system was last invoked.
   @override

--- a/lib/src/core/systems/void_entity_system.dart
+++ b/lib/src/core/systems/void_entity_system.dart
@@ -6,7 +6,7 @@ part of '../../../dartemis.dart';
 /// to concern yourself about aspects or entities.
 abstract class VoidEntitySystem extends EntitySystem {
   /// Create the [VoidEntitySystem].
-  VoidEntitySystem() : super(Aspect.empty());
+  VoidEntitySystem({super.group}) : super(Aspect.empty());
 
   @override
   void processEntities(Iterable<Entity> entities) => processSystem();

--- a/lib/src/core/systems/void_entity_system.dart
+++ b/lib/src/core/systems/void_entity_system.dart
@@ -9,7 +9,7 @@ abstract class VoidEntitySystem extends EntitySystem {
   VoidEntitySystem() : super(Aspect.empty());
 
   @override
-  void processEntities(Iterable<int> entities) => processSystem();
+  void processEntities(Iterable<Entity> entities) => processSystem();
 
   /// Execute the logic for this system.
   void processSystem();

--- a/lib/src/core/utils/bag.dart
+++ b/lib/src/core/utils/bag.dart
@@ -2,8 +2,7 @@ part of '../../../dartemis.dart';
 
 /// Collection type a bit like List but does not preserve the order of its
 /// entities, speedwise it is very good, especially suited for games.
-// ignore: prefer_mixin
-class Bag<E> with IterableMixin<E> {
+class Bag<E> with Iterable<E> {
   List<E?> _data;
   int _size = 0;
 

--- a/lib/src/core/utils/entity_bag.dart
+++ b/lib/src/core/utils/entity_bag.dart
@@ -1,32 +1,31 @@
 part of '../../../dartemis.dart';
 
 /// A [Bag] that uses a [BitSet] to manage entities. Results in faster
-/// removement of entities.
-// ignore: prefer_mixin
-class EntityBag with IterableMixin<int> {
+/// removal of entities.
+class EntityBag with Iterable<Entity> {
   BitSet _entities;
 
   /// Creates an [EntityBag].
   EntityBag() : _entities = BitSet(32);
 
-  /// Add a new [element]. If the element already exists, nothing changes.
-  void add(int element) {
-    if (element >= _entities.length) {
-      _entities = BitSet.fromBitSet(_entities, length: element);
+  /// Add a new [entity]. If the entity already exists, nothing changes.
+  void add(Entity entity) {
+    if (entity._id >= _entities.length) {
+      _entities = BitSet.fromBitSet(_entities, length: entity._id + 1);
     }
-    _entities[element] = true;
+    _entities[entity._id] = true;
   }
 
-  /// Removes [element]. Returns `true` if there was an element and `false`
+  /// Removes [entity]. Returns `true` if there was an element and `false`
   /// otherwise.
-  bool remove(int element) {
-    final result = _entities[element];
-    _entities[element] = false;
+  bool remove(Entity entity) {
+    final result = _entities[entity._id];
+    _entities[entity._id] = false;
     return result;
   }
 
   @override
-  bool contains(covariant int element) => _entities[element];
+  bool contains(covariant Entity element) => _entities[element._id];
 
   @override
   int get length => _entities.cardinality;
@@ -35,5 +34,6 @@ class EntityBag with IterableMixin<int> {
   void clear() => _entities.clearAll();
 
   @override
-  Iterator<int> get iterator => _entities.toIntValues().iterator;
+  Iterator<Entity> get iterator =>
+      _entities.toIntValues().map(Entity._).iterator;
 }

--- a/lib/src/core/world.dart
+++ b/lib/src/core/world.dart
@@ -21,7 +21,7 @@ class World {
   final Map<int, int> _frame = {0: 0, -1: 0};
   final Map<int, double> _time = {0: 0.0, -1: 0.0};
 
-  final Set<int> _entitiesMarkedForDeletion = <int>{};
+  final Set<Entity> _entitiesMarkedForDeletion = <Entity>{};
 
   /// The time that passed since the last time [process] was called.
   double delta = 0;
@@ -96,7 +96,7 @@ class World {
 
   /// Create and return a new or reused [int] instance, optionally with
   /// [components].
-  int createEntity<T extends Component>([List<T> components = const []]) {
+  Entity createEntity<T extends Component>([List<T> components = const []]) {
     final e = _entityManager._createEntityInstance();
     for (final component in components) {
       addComponent(e, component);
@@ -106,7 +106,7 @@ class World {
   }
 
   /// Adds a [component] to the [entity].
-  void addComponent<T extends Component>(int entity, T component) =>
+  void addComponent<T extends Component>(Entity entity, T component) =>
       componentManager._addComponent(
         entity,
         ComponentType.getTypeFor(component.runtimeType),
@@ -114,20 +114,20 @@ class World {
       );
 
   /// Adds [components] to the [entity].
-  void addComponents<T extends Component>(int entity, List<T> components) {
+  void addComponents<T extends Component>(Entity entity, List<T> components) {
     for (final component in components) {
       addComponent(entity, component);
     }
   }
 
   /// Removes a [Component] of type [T] from the [entity].
-  void removeComponent<T extends Component>(int entity) =>
+  void removeComponent<T extends Component>(Entity entity) =>
       componentManager._removeComponent(entity, ComponentType.getTypeFor(T));
 
   /// Moves a [Component] of type [T] from the [srcEntity] to the [dstEntity].
   /// if the [srcEntity] does not have the [Component] of type [T] nothing will
   /// happen.
-  void moveComponent<T extends Component>(int srcEntity, int dstEntity) =>
+  void moveComponent<T extends Component>(Entity srcEntity, Entity dstEntity) =>
       componentManager._moveComponent(
         srcEntity,
         dstEntity,
@@ -205,7 +205,7 @@ class World {
   }
 
   /// Delete an entity.
-  void _deleteEntity(int entity) {
+  void _deleteEntity(Entity entity) {
     for (final manager in _managers.values) {
       manager.deleted(entity);
     }
@@ -232,12 +232,12 @@ class World {
   void deleteAllEntities() {
     entityManager._entities
         .toIntValues()
-        .forEach(_entitiesMarkedForDeletion.add);
+        .forEach((id) => _entitiesMarkedForDeletion.add(Entity._(id)));
     _deleteEntities();
   }
 
-  /// Adds a [int entity] to this world.
-  void addEntity(int entity) {
+  /// Adds a [Entity entity] to this world.
+  void addEntity(Entity entity) {
     entityManager._add(entity);
     for (final manager in _managers.values) {
       manager.added(entity);
@@ -246,7 +246,7 @@ class World {
 
   /// Mark an [entity] for deletion from the world. Will be deleted after the
   /// current system finished running.
-  void deleteEntity(int entity) {
+  void deleteEntity(Entity entity) {
     _entitiesMarkedForDeletion.add(entity);
   }
 
@@ -269,7 +269,7 @@ class World {
   }
 
   /// Get all components belonging to this entity.
-  List<Component> getComponents(int entity) =>
+  List<Component> getComponents(Entity entity) =>
       _componentManager.getComponentsFor(entity);
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,9 @@
 name: dartemis
-version: 0.9.9
+version: 0.10.0-dev
 description: An Entity System Framework for game development. Based on Artemis.
 repository: https://github.com/denniskaselow/dartemis
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: ^3.3.0
 
 dependencies:
   meta: ^1.8.0
@@ -12,4 +12,4 @@ dev_dependencies:
   build_runner: ^2.0.0
   build_web_compilers: ^4.0.0
   mockito: ^5.4.0
-  test: ^1.16.0
+  test: ^1.23.0

--- a/test/dartemis/core/component_manager_test.dart
+++ b/test/dartemis/core/component_manager_test.dart
@@ -116,10 +116,14 @@ void main() {
         'exist', () {
       final componentA = Component0();
       world.createEntity([componentA]);
+      for (var i = 0; i < 1000; i++) {
+        world.createEntity<Component>([]);
+      }
+      final highIdEntity = world.createEntity<Component>([]);
 
       expect(
         world.componentManager.getComponent<Component0>(
-          1000,
+          highIdEntity,
           ComponentType.getTypeFor(Component0),
         ),
         isNull,

--- a/test/dartemis/core/managers/group_manager_test.dart
+++ b/test/dartemis/core/managers/group_manager_test.dart
@@ -5,9 +5,9 @@ void main() {
   group('GroupManager tests', () {
     late World world;
     late GroupManager sut;
-    late int entityA;
-    late int entityAB;
-    late int entity0;
+    late Entity entityA;
+    late Entity entityAB;
+    late Entity entity0;
     setUp(() {
       world = World();
       sut = GroupManager();

--- a/test/dartemis/core/managers/tag_manager_test.dart
+++ b/test/dartemis/core/managers/tag_manager_test.dart
@@ -7,8 +7,8 @@ void main() {
 
     late World world;
     late TagManager sut;
-    late int entityWithTag;
-    late int entityWithoutTag;
+    late Entity entityWithTag;
+    late Entity entityWithoutTag;
     setUp(() {
       world = World();
       sut = TagManager();

--- a/test/dartemis/core/systems/interval_entity_system_test.dart
+++ b/test/dartemis/core/systems/interval_entity_system_test.dart
@@ -25,5 +25,5 @@ void main() {
 class TestIntervalEntitySystem extends IntervalEntitySystem {
   TestIntervalEntitySystem(double interval) : super(interval, Aspect.empty());
   @override
-  void processEntities(Iterable<int> entities) {}
+  void processEntities(Iterable<Entity> entities) {}
 }

--- a/test/dartemis/core/systems/interval_entity_system_test.dart
+++ b/test/dartemis/core/systems/interval_entity_system_test.dart
@@ -8,6 +8,7 @@ void main() {
       final sut = TestIntervalEntitySystem(40);
       world
         ..addSystem(sut)
+        ..initialize()
         ..delta = 16;
 
       expect(sut.checkProcessing(), equals(false));

--- a/test/dartemis/core/world_test.dart
+++ b/test/dartemis/core/world_test.dart
@@ -6,34 +6,12 @@ import 'package:test/test.dart';
 import 'components_setup.dart';
 import 'world_test.mocks.dart';
 
-// mixingIn because of https://github.com/dart-lang/sdk/issues/49687
 @GenerateNiceMocks(
   [
-    MockSpec<EntitySystem>(
-      as: #MockEntitySystem2,
-      // ignore: deprecated_member_use
-      mixingIn: [
-        MockEntitySystemMixin,
-      ],
-    ),
-    MockSpec<EntitySystem>(
-      // ignore: deprecated_member_use
-      mixingIn: [
-        MockEntitySystemMixin,
-      ],
-    ),
-    MockSpec<ComponentManager>(
-      // ignore: deprecated_member_use
-      mixingIn: [
-        MockComponentManagerMixin,
-      ],
-    ),
-    MockSpec<Manager>(
-      // ignore: deprecated_member_use
-      mixingIn: [
-        MockManagerMixin,
-      ],
-    ),
+    MockSpec<EntitySystem>(as: #MockEntitySystem2),
+    MockSpec<EntitySystem>(),
+    MockSpec<ComponentManager>(),
+    MockSpec<Manager>(),
   ],
 )
 void main() {
@@ -56,7 +34,7 @@ void main() {
         ..addSystem(system)
         ..initialize();
 
-      verify(system.initialize()).called(1);
+      verify(system.initialize(world)).called(1);
     });
     test("the same system can't be added twice", () {
       world.addSystem(system);
@@ -81,7 +59,7 @@ void main() {
       when(system.passive).thenReturn(true);
 
       world
-        ..addSystem(system, passive: true)
+        ..addSystem(system)
         ..process();
 
       verifyNever(system.process());
@@ -94,7 +72,7 @@ void main() {
 
       world
         ..addSystem(system)
-        ..addSystem(system2, group: 1)
+        ..addSystem(system2)
         ..process();
       verify(system.process()).called(1);
       verifyNever(system2.process());
@@ -111,7 +89,7 @@ void main() {
 
       world
         ..addSystem(system)
-        ..addSystem(system2, group: 1)
+        ..addSystem(system2)
         ..delta = 10.0
         ..process()
         ..delta = 20.0
@@ -131,7 +109,7 @@ void main() {
         ..addManager(manager)
         ..initialize();
 
-      verify(manager.initialize()).called(1);
+      verify(manager.initialize(world)).called(1);
     });
     test('world initializes added managers', () {
       world.addManager(MockManager());
@@ -502,7 +480,8 @@ class TestEntitySystemForComponent3 extends EntityProcessingSystem {
   TestEntitySystemForComponent3() : super(Aspect.forAllOf([Component3]));
 
   @override
-  void initialize() {
+  void initialize(World world) {
+    super.initialize(world);
     mapper = Mapper<Component3>(world);
   }
 
@@ -524,7 +503,8 @@ class TestEntitySystemWithInteractingDeletedEntities extends EntitySystem {
       : super(Aspect.forAllOf([Component0]));
 
   @override
-  void initialize() {
+  void initialize(World world) {
+    super.initialize(world);
     mapper0 = Mapper<Component0>(world);
   }
 

--- a/test/dartemis/core/world_test.dart
+++ b/test/dartemis/core/world_test.dart
@@ -6,33 +6,29 @@ import 'package:test/test.dart';
 import 'components_setup.dart';
 import 'world_test.mocks.dart';
 
-@GenerateMocks(
-  [],
-  customMocks: [
+// mixingIn because of https://github.com/dart-lang/sdk/issues/49687
+@GenerateNiceMocks(
+  [
     MockSpec<EntitySystem>(
       as: #MockEntitySystem2,
-      onMissingStub: OnMissingStub.returnDefault,
       // ignore: deprecated_member_use
       mixingIn: [
         MockEntitySystemMixin,
       ],
     ),
     MockSpec<EntitySystem>(
-      onMissingStub: OnMissingStub.returnDefault,
       // ignore: deprecated_member_use
       mixingIn: [
         MockEntitySystemMixin,
       ],
     ),
     MockSpec<ComponentManager>(
-      onMissingStub: OnMissingStub.returnDefault,
       // ignore: deprecated_member_use
       mixingIn: [
         MockComponentManagerMixin,
       ],
     ),
     MockSpec<Manager>(
-      onMissingStub: OnMissingStub.returnDefault,
       // ignore: deprecated_member_use
       mixingIn: [
         MockManagerMixin,
@@ -208,8 +204,8 @@ void main() {
   });
   group('integration tests for World.process()', () {
     late World world;
-    late int entityAB;
-    late int entityAC;
+    late Entity entityAB;
+    late Entity entityAC;
     late EntitySystemStarter systemStarter;
     setUp(() {
       world = World();
@@ -334,9 +330,9 @@ Adding a component will get the entity processed''', () {
   });
   group('isUpdateNeededForSystem', () {
     late World world;
-    late int entityA;
-    late int entityB;
-    late int entityC;
+    late Entity entityA;
+    late Entity entityB;
+    late Entity entityC;
     late TestEntitySystem es;
     setUp(() {
       world = World();
@@ -431,11 +427,11 @@ typedef EntitySystemStarter = void Function(
 
 class TestEntitySystem extends EntitySystem {
   bool isSetup = true;
-  List<int> _expectedEntities;
+  List<Entity> _expectedEntities;
   TestEntitySystem(super.aspect, this._expectedEntities);
 
   @override
-  void processEntities(Iterable<int> entities) {
+  void processEntities(Iterable<Entity> entities) {
     final length = _expectedEntities.length;
     expect(entities.length, length);
     for (final entity in entities) {
@@ -494,7 +490,7 @@ class TestEntitySystemWithMoreThan32Components extends EntitySystem {
         );
 
   @override
-  void processEntities(Iterable<int> entities) {}
+  void processEntities(Iterable<Entity> entities) {}
 
   @override
   bool checkProcessing() => true;
@@ -511,7 +507,7 @@ class TestEntitySystemForComponent3 extends EntityProcessingSystem {
   }
 
   @override
-  void processEntity(int entity) {
+  void processEntity(Entity entity) {
     final component = mapper.getSafe(entity);
 
     expect(
@@ -536,7 +532,7 @@ class TestEntitySystemWithInteractingDeletedEntities extends EntitySystem {
   bool checkProcessing() => true;
 
   @override
-  void processEntities(Iterable<int> entities) {
+  void processEntities(Iterable<Entity> entities) {
     // some interaction that causes one entity to be deleted
     world.deleteEntity(entities.last);
 

--- a/test/dartemis/core/world_test.mocks.dart
+++ b/test/dartemis/core/world_test.mocks.dart
@@ -111,7 +111,7 @@ class MockEntitySystem2 extends _i1.Mock
       );
 
   @override
-  void processEntities(Iterable<int>? entities) => super.noSuchMethod(
+  void processEntities(Iterable<_i2.Entity>? entities) => super.noSuchMethod(
         Invocation.method(
           #processEntities,
           [entities],
@@ -149,7 +149,7 @@ class MockEntitySystem2 extends _i1.Mock
 
   @override
   void addComponent<T extends _i2.Component>(
-    int? entity,
+    _i2.Entity? entity,
     T? component,
   ) =>
       super.noSuchMethod(
@@ -164,7 +164,7 @@ class MockEntitySystem2 extends _i1.Mock
       );
 
   @override
-  void removeComponent<T extends _i2.Component>(int? entity) =>
+  void removeComponent<T extends _i2.Component>(_i2.Entity? entity) =>
       super.noSuchMethod(
         Invocation.method(
           #removeComponent,
@@ -174,7 +174,7 @@ class MockEntitySystem2 extends _i1.Mock
       );
 
   @override
-  void deleteFromWorld(int? entity) => super.noSuchMethod(
+  void deleteFromWorld(_i2.Entity? entity) => super.noSuchMethod(
         Invocation.method(
           #deleteFromWorld,
           [entity],
@@ -265,7 +265,7 @@ class MockEntitySystem extends _i1.Mock
       );
 
   @override
-  void processEntities(Iterable<int>? entities) => super.noSuchMethod(
+  void processEntities(Iterable<_i2.Entity>? entities) => super.noSuchMethod(
         Invocation.method(
           #processEntities,
           [entities],
@@ -303,7 +303,7 @@ class MockEntitySystem extends _i1.Mock
 
   @override
   void addComponent<T extends _i2.Component>(
-    int? entity,
+    _i2.Entity? entity,
     T? component,
   ) =>
       super.noSuchMethod(
@@ -318,7 +318,7 @@ class MockEntitySystem extends _i1.Mock
       );
 
   @override
-  void removeComponent<T extends _i2.Component>(int? entity) =>
+  void removeComponent<T extends _i2.Component>(_i2.Entity? entity) =>
       super.noSuchMethod(
         Invocation.method(
           #removeComponent,
@@ -328,7 +328,7 @@ class MockEntitySystem extends _i1.Mock
       );
 
   @override
-  void deleteFromWorld(int? entity) => super.noSuchMethod(
+  void deleteFromWorld(_i2.Entity? entity) => super.noSuchMethod(
         Invocation.method(
           #deleteFromWorld,
           [entity],
@@ -378,7 +378,8 @@ class MockComponentManager extends _i1.Mock
       ) as List<T>);
 
   @override
-  List<_i2.Component> getComponentsFor(int? entity) => (super.noSuchMethod(
+  List<_i2.Component> getComponentsFor(_i2.Entity? entity) =>
+      (super.noSuchMethod(
         Invocation.method(
           #getComponentsFor,
           [entity],
@@ -399,7 +400,7 @@ class MockComponentManager extends _i1.Mock
 
   @override
   T? getComponent<T extends _i2.Component>(
-    int? entity,
+    _i2.Entity? entity,
     _i2.ComponentType? componentType,
   ) =>
       (super.noSuchMethod(
@@ -414,7 +415,7 @@ class MockComponentManager extends _i1.Mock
       ) as T?);
 
   @override
-  void added(int? entity) => super.noSuchMethod(
+  void added(_i2.Entity? entity) => super.noSuchMethod(
         Invocation.method(
           #added,
           [entity],
@@ -423,7 +424,7 @@ class MockComponentManager extends _i1.Mock
       );
 
   @override
-  void deleted(int? entity) => super.noSuchMethod(
+  void deleted(_i2.Entity? entity) => super.noSuchMethod(
         Invocation.method(
           #deleted,
           [entity],
@@ -470,7 +471,7 @@ class MockManager extends _i1.Mock
       );
 
   @override
-  void added(int? entity) => super.noSuchMethod(
+  void added(_i2.Entity? entity) => super.noSuchMethod(
         Invocation.method(
           #added,
           [entity],
@@ -479,7 +480,7 @@ class MockManager extends _i1.Mock
       );
 
   @override
-  void deleted(int? entity) => super.noSuchMethod(
+  void deleted(_i2.Entity? entity) => super.noSuchMethod(
         Invocation.method(
           #deleted,
           [entity],

--- a/test/dartemis/core/world_test.mocks.dart
+++ b/test/dartemis/core/world_test.mocks.dart
@@ -32,15 +32,22 @@ class _FakeWorld_0 extends _i1.SmartFake implements _i2.World {
 /// A class which mocks [EntitySystem].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEntitySystem2 extends _i1.Mock
-    with _i2.MockEntitySystemMixin
-    implements _i2.EntitySystem {
+class MockEntitySystem2 extends _i1.Mock implements _i2.EntitySystem {
   @override
   bool get passive => (super.noSuchMethod(
         Invocation.getter(#passive),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
+  @override
+  set passive(bool? _passive) => super.noSuchMethod(
+        Invocation.setter(
+          #passive,
+          _passive,
+        ),
+        returnValueForMissingStub: null,
+      );
 
   @override
   int get group => (super.noSuchMethod(
@@ -130,10 +137,10 @@ class MockEntitySystem2 extends _i1.Mock
       ) as bool);
 
   @override
-  void initialize() => super.noSuchMethod(
+  void initialize(_i2.World? world) => super.noSuchMethod(
         Invocation.method(
           #initialize,
-          [],
+          [world],
         ),
         returnValueForMissingStub: null,
       );
@@ -186,15 +193,22 @@ class MockEntitySystem2 extends _i1.Mock
 /// A class which mocks [EntitySystem].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEntitySystem extends _i1.Mock
-    with _i2.MockEntitySystemMixin
-    implements _i2.EntitySystem {
+class MockEntitySystem extends _i1.Mock implements _i2.EntitySystem {
   @override
   bool get passive => (super.noSuchMethod(
         Invocation.getter(#passive),
         returnValue: false,
         returnValueForMissingStub: false,
       ) as bool);
+
+  @override
+  set passive(bool? _passive) => super.noSuchMethod(
+        Invocation.setter(
+          #passive,
+          _passive,
+        ),
+        returnValueForMissingStub: null,
+      );
 
   @override
   int get group => (super.noSuchMethod(
@@ -284,10 +298,10 @@ class MockEntitySystem extends _i1.Mock
       ) as bool);
 
   @override
-  void initialize() => super.noSuchMethod(
+  void initialize(_i2.World? world) => super.noSuchMethod(
         Invocation.method(
           #initialize,
-          [],
+          [world],
         ),
         returnValueForMissingStub: null,
       );
@@ -340,9 +354,7 @@ class MockEntitySystem extends _i1.Mock
 /// A class which mocks [ComponentManager].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockComponentManager extends _i1.Mock
-    with _i2.MockComponentManagerMixin
-    implements _i2.ComponentManager {
+class MockComponentManager extends _i1.Mock implements _i2.ComponentManager {
   @override
   _i2.World get world => (super.noSuchMethod(
         Invocation.getter(#world),
@@ -357,10 +369,28 @@ class MockComponentManager extends _i1.Mock
       ) as _i2.World);
 
   @override
-  void initialize() => super.noSuchMethod(
+  void initialize(_i2.World? world) => super.noSuchMethod(
         Invocation.method(
           #initialize,
-          [],
+          [world],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void registerSystem(_i2.EntitySystem? system) => super.noSuchMethod(
+        Invocation.method(
+          #registerSystem,
+          [system],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void removeComponentsOfEntity(_i2.Entity? entity) => super.noSuchMethod(
+        Invocation.method(
+          #removeComponentsOfEntity,
+          [entity],
         ),
         returnValueForMissingStub: null,
       );
@@ -445,9 +475,7 @@ class MockComponentManager extends _i1.Mock
 /// A class which mocks [Manager].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockManager extends _i1.Mock
-    with _i2.MockManagerMixin
-    implements _i2.Manager {
+class MockManager extends _i1.Mock implements _i2.Manager {
   @override
   _i2.World get world => (super.noSuchMethod(
         Invocation.getter(#world),
@@ -462,10 +490,10 @@ class MockManager extends _i1.Mock
       ) as _i2.World);
 
   @override
-  void initialize() => super.noSuchMethod(
+  void initialize(_i2.World? world) => super.noSuchMethod(
         Invocation.method(
           #initialize,
-          [],
+          [world],
         ),
         returnValueForMissingStub: null,
       );


### PR DESCRIPTION
Use extension types to use `Entity` instead of `int` for entities